### PR TITLE
Revise disclaimer and mission statement in Margo doc

### DIFF
--- a/system-design/what-is-margo.md
+++ b/system-design/what-is-margo.md
@@ -8,9 +8,9 @@ Find out more about the Margo initiative and how to become engaged at [margo.org
 
 > **Disclaimer**
 
-This is a commit *snapshot* rendering of the of work-in-progress Margo Specification draft from the repository [=@=reponame=@=](https://github.com/=@=reponame=@=), commit `=@=commit=@=`.
+Preview Release 1 of the Margo Specification draft in the [Margo Specification] repository is a work in progress.
 
-Do not attempt to implement this version of the Specification or reference this version as authoritative in any way!
+Do not implement this version of the specification or treat it as authoritative in any way.
 
 ## Mission Statement
 

--- a/system-design/what-is-margo.md
+++ b/system-design/what-is-margo.md
@@ -10,7 +10,7 @@ Find out more about the Margo initiative and how to become engaged at [margo.org
 
 Preview Release 1 of the Margo Specification draft in the [Margo Specification](https://github.com/margo/specification) repository is a work in progress.
 
-Do not implement this version of the specification or treat it as authoritative in any way.
+Do not implement this version of the Specification or treat it as authoritative in any way.
 
 ## Mission Statement
 

--- a/system-design/what-is-margo.md
+++ b/system-design/what-is-margo.md
@@ -52,8 +52,6 @@ The core deliverables for Margo address the mission to enable interoperability a
 
 Read more about [Margo's deliverables](https://margo.org/about/who-are-we/#deliverables) on our web site.
 
-## License
-
-=@=copyright=@=
-
-See [License](https://github.com/margo/specification?#licenses).
+## Copyright License & Source Code Contributions
+- See [Copyright License](https://github.com/margo#copyright-license).
+- See the [Source Code Contributions License](https://github.com/margo#source-code-contributions)

--- a/system-design/what-is-margo.md
+++ b/system-design/what-is-margo.md
@@ -8,7 +8,7 @@ Find out more about the Margo initiative and how to become engaged at [margo.org
 
 > **Disclaimer**
 
-Preview Release 1 of the Margo Specification draft in the [Margo Specification] repository is a work in progress.
+Preview Release 1 of the Margo Specification draft in the [Margo Specification](https://github.com/margo/specification) repository is a work in progress.
 
 Do not implement this version of the specification or treat it as authoritative in any way.
 


### PR DESCRIPTION
Remove and update broken links and text

On this page ([What is Margo? | Margo Documentation](https://docs.margo.org/what-is-margo)) there are some errors:

“This is a commit snapshot rendering of the of work-in-progress Margo Specification draft from the repository [=@=reponame=@=](https://github.com/=@=reponame=@=), commit =@=commit=@=.”

“[License](https://docs.margo.org/what-is-margo#license) =@=copyright=@=“
