### PR TITLE
docs(concept): clarifies device capabilities scope/boundary in margo …

### DIFF
--- a/system-design/concepts/workload-fleet-managers/device-capabilities.md
+++ b/system-design/concepts/workload-fleet-managers/device-capabilities.md
@@ -2,7 +2,7 @@
 
 The purpose of device capabilities reporting is to ensure the Workload Fleet Management (WFM) solution has the information needed to pair workloads with compatible edge devices. The device's capabilities are reported to the WFM web service using the [Device Capabilities API](../../specification/margo-management-interface/device-capabilities.md).
 
-**Note:** _Devices must only report capabilities that are explicitly exposed and accessible to Margo workloads. If a device feature is isolated from the Margo runtime environment, it must be excluded from the capabilities report. For example, an onboard camera used exclusively for local device security—and completely isolated from Margo—must not be reported as an available capability. This ensures workloads are not scheduled against unavailable or restricted hardware resources._
+**Note:** _Devices report only the capabilities that are explicitly exposed and accessible to Margo workloads. If a device feature is isolated from the Margo runtime environment, it is excluded from the capabilities report. For example, an onboard camera used exclusively for local device security—and completely isolated from Margo—is not reported as an available capability. This ensures workloads are not scheduled against unavailable or restricted hardware resources._
 
 ### Device Capability Reporting
 

--- a/system-design/concepts/workload-fleet-managers/device-capabilities.md
+++ b/system-design/concepts/workload-fleet-managers/device-capabilities.md
@@ -2,6 +2,8 @@
 
 The purpose of device capabilities reporting is to ensure the Workload Fleet Management (WFM) solution has the information needed to pair workloads with compatible edge devices. The device's capabilities are reported to the WFM web service using the [Device Capabilities API](../../specification/margo-management-interface/device-capabilities.md).
 
+**Note:** _Devices must only report capabilities that are explicitly exposed and accessible to Margo workloads. If a device feature is isolated from the Margo runtime environment, it must be excluded from the capabilities report. For example, an onboard camera used exclusively for local device security—and completely isolated from Margo—must not be reported as an available capability. This ensures workloads are not scheduled against unavailable or restricted hardware resources._
+
 ### Device Capability Reporting
 
 The device owner reports their device's capabilities and characteristics, via the device API, when onboarding the device with the Workload Fleet Management solution. Additionally, during the lifecycle of the edge device, if there is a change that impacts the reported characteristics, the device updates the Workload Fleet Manager with the latest information via the [Device Capabilities API](../../specification/margo-management-interface/device-capabilities.md). 


### PR DESCRIPTION
### Description

Device capabilities documentation doesn't clarify that only those capabilities are reported which are explicitly exposed for Margo usage.

#### Issues Addressed

https://github.com/margo/specification/issues/159

Another part of it is covered here: https://github.com/margo/specification/pull/182

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [ ] New enhancement (change that adds specification content)
- [x] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.